### PR TITLE
docker: bump base os to ubuntu 22.04 with cuda 12.2 and cudnn 8

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -25,7 +25,7 @@ jobs:
           images: noelmni/deep-fcd
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -3,6 +3,9 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - dev
 
 jobs:
   push_to_registry:
@@ -23,6 +26,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: noelmni/deep-fcd
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.7", "3.8"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test-inference-pipeline.yml
+++ b/.github/workflows/test-inference-pipeline.yml
@@ -52,7 +52,9 @@ jobs:
           CI_TESTING_PRED_DIR: "/home/ga/io"
           
       - name: Run tests to compare outputs with previous validated runs
-        run: bash ./tests/run_tests.sh
+        run: |
+          chmod +x ./tests/run_tests.sh
+          conda run --no-capture-output --name deepFCD ./tests/run_tests.sh
         env:
           CI_TESTING_PATIENT_ID: "sub-00055"
           CI_TESTING_PRED_DIR: "/home/ga/io"

--- a/.github/workflows/test-inference-pipeline.yml
+++ b/.github/workflows/test-inference-pipeline.yml
@@ -39,9 +39,9 @@ jobs:
           BASE_URL=https://s3.amazonaws.com/openneuro.org/ds004199/${PATIENT_ID}/anat
           mkdir -p ~/io/${PATIENT_ID}
           echo "retrieving single-patient multimodal dataset.."
-          wget ${BASE_URL}/${PATIENT_ID}_acq-sag111_T1w.nii.gz\?versionId\=IKGWDiLR7B7ls2yPVyycJo.6R1Sqhujf -O ~/io/sub-00055/t1.nii.gz
-          wget ${BASE_URL}/${PATIENT_ID}_acq-tse3dvfl_FLAIR.nii.gz\?versionId\=HmzYoUuYkdbyd8jkpdJjVkZydRHNSqUX -O ~/io/sub-00055/flair.nii.gz
-          wget ${BASE_URL}/${PATIENT_ID}_acq-tse3dvfl_FLAIR_roi.nii.gz\?versionId\=ulmEU3nb8WCvGwcwTbkcdNSVr07PMPQN -O ~/io/sub-00055/label.nii.gz
+          curl -L "${BASE_URL}/${PATIENT_ID}_acq-sag111_T1w.nii.gz?versionId=IKGWDiLR7B7ls2yPVyycJo.6R1Sqhujf" -o ~/io/sub-00055/t1.nii.gz
+          curl -L "${BASE_URL}/${PATIENT_ID}_acq-tse3dvfl_FLAIR.nii.gz?versionId=HmzYoUuYkdbyd8jkpdJjVkZydRHNSqUX" -o ~/io/sub-00055/flair.nii.gz
+          curl -L "${BASE_URL}/${PATIENT_ID}_acq-tse3dvfl_FLAIR_roi.nii.gz?versionId=ulmEU3nb8WCvGwcwTbkcdNSVr07PMPQN" -o ~/io/sub-00055/label.nii.gz
 
       - name: Run inference for deepFCD
         run: |

--- a/.github/workflows/test-inference-pipeline.yml
+++ b/.github/workflows/test-inference-pipeline.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run inference for deepFCD
         run: |
-          conda run --name deepFCD ./app/inference.py ${CI_TESTING_PATIENT_ID} t1.nii.gz flair.nii.gz ~/io cuda 1 1
+          conda run --no-capture-output --name deepFCD ./app/inference.py ${CI_TESTING_PATIENT_ID} t1.nii.gz flair.nii.gz ~/io cuda 1 1
         env:
           CI_TESTING_PATIENT_ID: "sub-00055"
           CI_TESTING_GT: "./tests/segmentations/sub-00055/sub-00055_label_dilated_final.nii.gz"

--- a/.github/workflows/test-inference-pipeline.yml
+++ b/.github/workflows/test-inference-pipeline.yml
@@ -20,16 +20,18 @@ jobs:
       - name: Install dependencies for deepMask
         run: |
           eval "$(conda shell.bash hook)"
-          conda create -n preprocess python=3.8
+          conda create --name preprocess python=3.8
           conda activate preprocess
           python -m pip install -r ./app/deepMask/app/requirements.txt
           conda deactivate
 
       - name: Install dependencies for deepFCD
         run: |
+          eval "$(conda shell.bash hook)"
+          conda create --name deepFCD -c conda-forge python=3.8.20 pygpu==0.7.6
+          conda activate deepFCD
           python -m pip install -r ./app/requirements.txt
-          conda install -c conda-forge pygpu==0.7.6
-          pip cache purge
+          conda deactivate
 
       - name: Download openneuro.org dataset to test the inference pipeline # https://openneuro.org/datasets/ds004199/versions/1.0.5
         run: |
@@ -43,7 +45,7 @@ jobs:
 
       - name: Run inference for deepFCD
         run: |
-          ./app/inference.py ${CI_TESTING_PATIENT_ID} t1.nii.gz flair.nii.gz ~/io cuda 1 1
+          conda run --name deepFCD ./app/inference.py ${CI_TESTING_PATIENT_ID} t1.nii.gz flair.nii.gz ~/io cuda 1 1
         env:
           CI_TESTING_PATIENT_ID: "sub-00055"
           CI_TESTING_GT: "./tests/segmentations/sub-00055/sub-00055_label_dilated_final.nii.gz"

--- a/.github/workflows/test-inference-pipeline.yml
+++ b/.github/workflows/test-inference-pipeline.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,11 @@ USER user
 ENV HOME=/home/user
 RUN chmod 777 /home/user
 
-# specify conda version
-ARG CONDA_VERSION=py38_23.11.0-2
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh \
-    && /bin/bash Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -b -p /home/user/conda \
-    && rm Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
-
-# RUN conda update -n base -c defaults conda
+# specify miniforge version
+ARG MINIFORGE_VERSION=25.3.1-0
+RUN wget https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh \
+    && bash Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh -b -p "${HOME}/conda" \
+    && rm Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh
 
 RUN git clone --depth 1 https://github.com/NOEL-MNI/deepMask.git \
     && rm -rf deepMask/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ USER user
 ENV HOME=/home/user
 RUN chmod 777 /home/user
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.2-0-Linux-x86_64.sh \
-    && /bin/bash Miniconda3-py38_23.5.2-0-Linux-x86_64.sh -b -p /home/user/conda \
-    && rm Miniconda3-py38_23.5.2-0-Linux-x86_64.sh
+# specify conda version
+ARG CONDA_VERSION=py38_23.11.0-2
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh \
+    && /bin/bash Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -b -p /home/user/conda \
+    && rm Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh
 
 # RUN conda update -n base -c defaults conda
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM noelmni/cuda:10.0-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+
 LABEL maintainer="Ravnoor Singh Gill <ravnoor@gmail.com>" \
         org.opencontainers.image.title="deepFCD" \
         org.opencontainers.image.description="Automated Detection of Focal Cortical Dysplasia using Deep Learning" \
         org.opencontainers.image.licenses="BSD-3-Clause" \
         org.opencontainers.image.source="https://github.com/NOEL-MNI/deepFCD" \
         org.opencontainers.image.url="https://github.com/NOEL-MNI/deepFCD"
-
-# manually update outdated repository key
-# fixes invalid GPG error: https://forums.developer.nvidia.com/t/gpg-error-http-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64/212904
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,14 +51,20 @@ RUN eval "$(conda shell.bash hook)" \
 
 COPY app/requirements.txt /app/requirements.txt
 
-RUN python -m pip install -r /app/requirements.txt \
-    && conda install -c conda-forge pygpu==0.7.6 \
-    && pip cache purge
+RUN eval "$(conda shell.bash hook)" \
+    && conda create -n deepFCD -c conda-forge python=3.8.20 pygpu==0.7.6 \
+    && conda activate deepFCD \
+    && python -m pip install -r /app/requirements.txt \
+    && conda deactivate
+
+RUN pip cache purge
 
 COPY app/ /app/
 
 COPY tests/ /tests/
 
 RUN sudo chmod -R 777 /app && sudo chmod +x /app/inference.py
+
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "deepFCD"]
 
 CMD ["python3"]

--- a/ci/runner.Dockerfile
+++ b/ci/runner.Dockerfile
@@ -1,4 +1,5 @@
-FROM noelmni/cuda:10.0-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+
 LABEL maintainer="Ravnoor Singh Gill <ravnoor@gmail.com>" \
         org.opencontainers.image.title="Self-hosted Github Actions runner for deepFCD" \
         org.opencontainers.image.description="Automated Detection of Focal Cortical Dysplasia using Deep Learning" \
@@ -6,46 +7,33 @@ LABEL maintainer="Ravnoor Singh Gill <ravnoor@gmail.com>" \
         org.opencontainers.image.source="https://github.com/NOEL-MNI/deepFCD" \
         org.opencontainers.image.url="https://github.com/NOEL-MNI/deepFCD"
 
-# manually update outdated repository key
-# fixes invalid GPG error: https://forums.developer.nvidia.com/t/gpg-error-http-developer-download-nvidia-com-compute-cuda-repos-ubuntu1804-x86-64/212904
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-
-ARG RUNNER_VERSION=2.309.0
-ARG NVM_VERSION=0.39.5
+ARG RUNNER_VERSION=2.328.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get install -y --no-install-recommends \
-    bash build-essential curl jq libssl-dev libffi-dev \
-    nano python3-dev software-properties-common unzip wget
-
-# install git 2.17+
-RUN add-apt-repository ppa:git-core/candidate -y
-RUN apt-get update
-RUN apt-get install -y git
-
-RUN apt-get remove nodejs npm
+    bash \
+    build-essential \
+    curl \
+    git \
+    jq \
+    libffi-dev \
+    libssl-dev \
+    nano \
+    unzip
 
 # github actions needs a non-root to run
 RUN useradd -m ga 
 WORKDIR /home/ga/actions-runner
 ENV HOME=/home/ga
 
-# https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker/60137919#60137919
-SHELL ["/bin/bash", "--login", "-i", "-c"]
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
-RUN source /root/.bashrc && nvm install 16
-SHELL ["/bin/bash", "--login", "-c"]
-
 # install Github Actions runner
 RUN curl -s -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
     tar xzf ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz && \
-    ./bin/installdependencies.sh
+    ./bin/installdependencies.sh && \
+    rm -f ./actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
 
-# RUN wget -c https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz && \
-#     ./bin/patchelf --set-interpreter /opt/glibc-2.28/lib/ld-linux-x86-64.so.2 --set-rpath /opt/glibc-2.28/lib/ /home/ga/.nvm/versions/node/v20.6.1/bin/node
-
-# add over the start.sh script
+# add the start.sh script
 ADD start-runner.sh start.sh
 
 # make the script executable
@@ -55,14 +43,17 @@ RUN chmod +x start.sh
 RUN chown -R ga /home/ga
 USER ga
 
-# install Conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_23.5.2-0-Linux-x86_64.sh && \
-    /bin/bash Miniconda3-py38_23.5.2-0-Linux-x86_64.sh -b && \
-    rm Miniconda3-py38_23.5.2-0-Linux-x86_64.sh && \
-    echo '. ~/miniconda3/etc/profile.d/conda.sh' >> ~/.bashrc
+# specify miniforge version
+ARG MINIFORGE_VERSION=25.3.1-0
+RUN curl -s -O -L https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh \
+    && bash Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh -b -p "${HOME}/conda" \
+    && rm Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh
+    
+# initialize conda
+RUN echo 'source "${HOME}/conda/etc/profile.d/conda.sh"' >> ~/.bashrc
 
 # create a dir to store inputs and outputs
-RUN mkdir ~/io
+RUN mkdir ${HOME}/io
 
 # set the entrypoint to the start.sh script
 ENTRYPOINT ["./start.sh"]

--- a/ci/runner.docker-compose.yml
+++ b/ci/runner.docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - driver: nvidia
               # count: 1
               device_ids: ['1']
-              capabilities: [gpu]
+              capabilities: [gpu,compute,video]
     # volumes:
         # - '$PWD/io:/io'
         # - /var/run/docker.sock:/var/run/docker.sock

--- a/ci/runner.docker-compose.yml
+++ b/ci/runner.docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   runner:
-    image: noelmni/deep-fcd:runner_latest
+    image: noelmni/deep-fcd_ci:cu122-ubuntu22.04-miniforge
     # command: '/app/inference.py FCD_001 T1.nii.gz FLAIR.nii.gz /io cuda0 1 1'
     # command: nvidia-smi
     # entrypoint: /bin/bash
@@ -8,15 +8,15 @@ services:
       context: .
       dockerfile: runner.Dockerfile
       args:
-        RUNNER_VERSION: '2.309.0'
-        NVM_VERSION: '0.39.5'
+        BASE_IMAGE_TAG: 12.2.2-cudnn8-devel-ubuntu22.04
+        RUNNER_VERSION: '2.328.0'
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
               # count: 1
-              device_ids: ['1']
+              device_ids: ['0']
               capabilities: [gpu,compute,video]
     # volumes:
         # - '$PWD/io:/io'

--- a/ci/runner.docker-compose.yml
+++ b/ci/runner.docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   runner:
     image: noelmni/deep-fcd:runner_latest

--- a/ci/start-runner.sh
+++ b/ci/start-runner.sh
@@ -21,7 +21,7 @@ cleanup() {
     ./config.sh remove --unattended --token ${REG_TOKEN}
 }
 
-export PATH=/home/ga/miniconda3/condabin:/home/ga/miniconda3/bin:$PATH
+export PATH=/home/ga/conda/bin:$PATH
 
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM


### PR DESCRIPTION
This pull request updates the project's Docker images and CI/CD workflows to use newer base images, modernizes the Python and Conda environments, and improves the reliability and maintainability of the build and test pipelines. The main themes are upgrading dependencies, improving environment setup, and enhancing CI/CD workflow robustness.

Most importantly, it introduces support for newer NVIDIA GPUs with a compute capability of 8.0 or higher. Older GPUs that were supported before will continue to be compatible with this update.

**Docker base image and Conda environment upgrades:**
- Updated the main `Dockerfile` and CI runner Dockerfile to use `nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04` instead of the older CUDA 10/Ubuntu 18.04 base, and switched from Miniconda to Miniforge for environment management, improving compatibility and maintainability. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-L12) [[2]](diffhunk://#diff-f6f9621ff6e7ddb6b7eaf6ed8a46d981ca4a21535e1cfcd71a7b2b82f2160d2dL1-R36)
- Revised the Conda environment setup in both Dockerfiles to use explicit environment creation and activation/deactivation, and updated the installation of dependencies accordingly. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L38-R39) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L55-R67) [[3]](diffhunk://#diff-f6f9621ff6e7ddb6b7eaf6ed8a46d981ca4a21535e1cfcd71a7b2b82f2160d2dL58-R56)

**CI/CD workflow improvements:**
- Upgraded all GitHub Actions used in workflow files (`actions/checkout`, `docker/build-push-action`, `actions/setup-python`) to their latest major versions for better security and support. [[1]](diffhunk://#diff-768bb2d7e0673a7ae2b43611022ef723ff230d7b4e67b340f07d8363c362551bL10-R13) [[2]](diffhunk://#diff-e803f47b6d2d0403e24452eee3724d7eec3fa4bce8601474c779cdd231fa707eL12-R17) [[3]](diffhunk://#diff-7970be07460d9b0b7c996d0f0da8c178e804910c4b16a076dfc50ef171600b89R6-R16)
- Enhanced the Docker image publishing workflow to trigger on pushes to the `dev` branch and improved Docker image tagging for better traceability. [[1]](diffhunk://#diff-7970be07460d9b0b7c996d0f0da8c178e804910c4b16a076dfc50ef171600b89R6-R16) [[2]](diffhunk://#diff-7970be07460d9b0b7c996d0f0da8c178e804910c4b16a076dfc50ef171600b89R29-R36)

**Testing and inference pipeline robustness:**
- Improved the test workflow by switching from `wget` to `curl` for dataset downloads, ensuring compatibility with redirects, and using Conda environments to isolate dependencies for both the preprocessing and inference steps. Also, made the test script executable and ran it within the created Conda environment for consistency.

**CI runner configuration updates:**
- Updated the CI runner Docker Compose file to use the new image and updated runner version, and revised device configuration for GPU access.
- Fixed the PATH export in the runner startup script to match the new Miniforge installation path.